### PR TITLE
Make panel wider to show longer page and artboard names

### DIFF
--- a/Symbol Instance Locator.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Symbol Instance Locator.sketchplugin/Contents/Sketch/script.cocoascript
@@ -3,7 +3,7 @@ var strPluginName = "Symbol Instance Locator",
 
 var uiButtons = [];
 
-var instancePanelWidth = 350,
+var instancePanelWidth = 500,
 	instancePanelHeight = 492 + 38 + 30, // 38 is for the button panel, 30 is for segmented control
 	instancePanelTitle = 44,
 	gutterWidth = 15;


### PR DESCRIPTION
The window often looks like the attached pic, i.e. most page and artboard names are cut off in a large document with a lot of nested symbols.

The best fix would probably be to make the window resizable and remember the user preference, but as a simple fix the window could be at least a little bit wider. Maybe the window would also work better with short names if the thumbnail were on the left?

![screen shot 2018-06-02 at 11 04 46](https://user-images.githubusercontent.com/1101002/40872800-cebb2484-6654-11e8-9404-83c210fc9a6b.png)
